### PR TITLE
Add documentation for crossover functions

### DIFF
--- a/src/crossover/blend.rs
+++ b/src/crossover/blend.rs
@@ -1,5 +1,26 @@
 use rand::{prelude::StdRng, Rng, SeedableRng};
 
+/**
+## Description:
+It uses the following formula to generate offsprings from parents:
+    C1 = (1-γ)P1 + γP2
+    C2 = (1-γ)P2 + γP1
+    Here, γ = (1+2ɑ)r - ɑ [ɑ is a fixed value, say 0.5 and r is a random value between 0 and 1]
+
+### Note:
+- The function can also take in an optional `seed` value of type `Option<u64>` for deterministic results.
+
+## Return:
+The return value is a tuple containing two offsprings of type `f32`
+
+## Example:
+```rust
+use genx::crossover::blend_crossover;
+
+let (parent1, parent2) = (13.37, 9.43);
+let (child1, child2) = blend_crossover(parent1, parent2, 0.5, None);
+```
+ */
 pub fn blend_crossover(parent1: f32, parent2: f32, alpha: f32, seed: Option<u64>) -> (f32, f32) {
     let mut prng = match seed {
         Some(val) => StdRng::seed_from_u64(val),

--- a/src/crossover/cycle.rs
+++ b/src/crossover/cycle.rs
@@ -6,9 +6,10 @@ use super::{check_continuous, check_length};
 
 /**
 ## Description:
-It uses the random crossover points to combine the parents same as per 1-Point crossover.
-To provide the great combination of parents it selects more than one crossover points to create the
-offspring or child.
+It identifies a number of so-called cycles between two parent chromosomes. Then, to form Child 1,
+cycle one is copied from parent 1, cycle 2 from parent 2, cycle 3 from parent 1, and so on. It
+attempts to create an offspring from the parents where every position is occupied by a corresponding
+element from one of the parents.
 
 ## Return:
 The return value is a tuple containing two offsprings of type `Vec<usize>`

--- a/src/crossover/cycle.rs
+++ b/src/crossover/cycle.rs
@@ -4,6 +4,24 @@ use itertools::multizip;
 
 use super::{check_continuous, check_length};
 
+/**
+## Description:
+It uses the random crossover points to combine the parents same as per 1-Point crossover.
+To provide the great combination of parents it selects more than one crossover points to create the
+offspring or child.
+
+## Return:
+The return value is a tuple containing two offsprings of type `Vec<usize>`
+
+## Example:
+```rust
+use genx::crossover::cycle_crossover;
+
+let parent1 = vec![1, 3, 4, 7, 0, 2, 6, 5];
+let parent2 = vec![2, 3, 4, 0, 7, 6, 1, 5];
+let (child1, child2) = cycle_crossover(&parent1, &parent2);
+```
+ */
 pub fn cycle_crossover(parent1: &Vec<usize>, parent2: &Vec<usize>) -> (Vec<usize>, Vec<usize>) {
   check_length(parent1, parent2);
 

--- a/src/crossover/linear.rs
+++ b/src/crossover/linear.rs
@@ -1,3 +1,25 @@
+
+/**
+## Description:
+It uses the linear combination of the present chromosomes to produce new children.
+SSuppose P<sub>1</sub> and P<sub>2</sub> are the parent values. Corresponding offspring chromosome values can be
+obtained as C<sub>i</sub> = ɑ<sub>i</sub>P<sub>1</sub> + β<sub>i</sub>P<sub>2</sub>, where i = 1,2,3...n
+
+### Note:
+- The function takes a vector of (ɑ, β) pairs as a parameter.
+
+## Return:
+The return value is a vector `Vec<f32>` containing children for each parameter.
+
+## Example:
+```rust
+use genx::crossover::linear_crossover;
+
+let (parent1, parent2) = (11.13, 12.19);
+let params = vec![(0.5, 0.5), (0.6, -0.4)];
+let children = linear_crossover(parent1, parent2, &params);
+```
+ */
 pub fn linear_crossover(parent1: f32, parent2: f32, parameters: &Vec<(f32, f32)>) -> Vec<f32> {
     let mut offsprings = Vec::with_capacity(parameters.len());
     for &(alpha, beta) in parameters.iter() {

--- a/src/crossover/mod.rs
+++ b/src/crossover/mod.rs
@@ -1,3 +1,46 @@
+//! Crossover is one of the prominent operators used in genetic algorithms.
+//! Crossover process is vital in generating new chromosomes by combing two or more parent
+//! chromosomes with the hope that they create new and efficient chromosomes.
+//! Crossover occurs after selection of pairs of parent chromosomes and helps in
+//! exchanging information between parents to create children.
+//!
+//! During crossover the
+//! parent chromosomes are taken in pair and their genes are exchanged in certain order
+//! to obtain off spring. These offspring become next generation parent chromosomes.
+//! It is performed by exchanging alleles between two selected parent
+//! chromosomes in order to explore new solution space.
+//!
+//! All the crossover functions take in atleast two arguments
+//! which are the two parent from which two offsprings are generated.
+//!
+//! Available crossover functions for binary encoded
+//! individuals are:
+//! * `single_point`
+//! * `multi_point`
+//! * `uniform`
+//! * `shuffle`
+//!
+//! Available crossover functions for real encoded
+//! individuals are:
+//! * `linear`
+//! * `blend`
+//! * `simulated_binary`
+//!
+//! Above all real encoded crossover techniques take in one additional parameter
+//! that determines the shift in values between the parents and offsprings.
+//!
+//! Available crossover functions for order encoded
+//! individuals are:
+//! * `cycle`
+//! * `order`
+//! * `partially_mapped`
+//! * `uniform_partially_mapped`
+//!
+//! For order encoded individuals the crossover function will panic in case
+//! of invalid order or missing elements. So values should be in range of
+//! 0..n-1 where n is length of the order encoded individual.
+//!
+//! You can read more about selection schemas and their working from the [research paper](http://ictactjournals.in/paper/IJSC_V6_I1_paper_4_pp_1083_1092.pdf)
 use std::collections::HashSet;
 
 pub mod single_point;

--- a/src/crossover/multi_point.rs
+++ b/src/crossover/multi_point.rs
@@ -2,6 +2,28 @@ use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 use super::check_length;
 
+/**
+## Description:
+It uses the random crossover points to combine the parents same as per 1-Point crossover.
+To provide the great combination of parents it selects more than one crossover points to create the
+offspring or child.
+
+### Note:
+- The function takes an integer `k` denoting the number of crossover points.
+- The function can also take in an optional `seed` value of type `Option<u64>` for deterministic results.
+
+## Return:
+The return value is a tuple containing two offsprings of type `Vec<bool>`
+
+## Example:
+```rust
+use genx::crossover::multi_point_crossover;
+
+let parent1 = vec![true, false, false, true, true, false, false, true];
+let parent2 = vec![true, true, true, false, true, false, true, true];
+let (child1, child2) = multi_point_crossover(&parent1, &parent2, 3, None);
+```
+ */
 pub fn multi_point_crossover(
     parent1: &Vec<bool>,
     parent2: &Vec<bool>,

--- a/src/crossover/order.rs
+++ b/src/crossover/order.rs
@@ -1,6 +1,26 @@
 use super::{check_continuous, check_length};
 use rand::{prelude::IteratorRandom, rngs::StdRng, SeedableRng};
 
+/**
+## Description:
+It constructs an offspring by choosing a substring of one parent and preserving the relative order
+of the elements of the other parent.
+
+### Note:
+- The function can also take in an optional `seed` value of type `Option<u64>` for deterministic results.
+
+## Return:
+The return value is a tuple containing two offsprings of type `Vec<usize>`
+
+## Example:
+```rust
+use genx::crossover::order_crossover;
+
+let parent1 = vec![1, 3, 4, 7, 0, 2, 6, 5];
+let parent2 = vec![2, 3, 4, 0, 7, 6, 1, 5];
+let (child1, child2) = order_crossover(&parent1, &parent2, None);
+```
+ */
 pub fn order_crossover(
     parent1: &Vec<usize>,
     parent2: &Vec<usize>,

--- a/src/crossover/partially_mapped.rs
+++ b/src/crossover/partially_mapped.rs
@@ -2,6 +2,27 @@ use super::{check_continuous, check_length};
 
 use rand::{SeedableRng, prelude::IteratorRandom, rngs::StdRng};
 
+/**
+## Description:
+It transmits ordering and values information from the parent strings to the offspring. A portion of
+one parent string is mapped onto a portion of the other parent string and the remaining information
+is exchanged.
+
+### Note:
+- The function can also take in an optional `seed` value of type `Option<u64>` for deterministic results.
+
+## Return:
+The return value is a tuple containing two offsprings of type `Vec<usize>`
+
+## Example:
+```rust
+use genx::crossover::partially_mapped_crossover;
+
+let parent1 = vec![1, 3, 4, 7, 0, 2, 6, 5];
+let parent2 = vec![2, 3, 4, 0, 7, 6, 1, 5];
+let (child1, child2) = partially_mapped_crossover(&parent1, &parent2, None);
+```
+ */
 pub fn partially_mapped_crossover(parent1: &Vec<usize>, parent2: &Vec<usize>, seed: Option<u64>) -> (Vec<usize>, Vec<usize>) {
   check_length(parent1, parent2);
 

--- a/src/crossover/shuffle.rs
+++ b/src/crossover/shuffle.rs
@@ -2,6 +2,29 @@ use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 
 use super::{check_length, single_point_crossover};
 
+/**
+## Description:
+Shuffle Crossover selects the two parents for crossover. It firstly randomly shuffles the genes in
+the both parents but in the same way. Then it applies the 1-Point crossover technique by randomly
+selecting a point as crossover point and then combines both parents to create two offspring. After
+performing 1-point crossover the genes in offspring are then unshuffled in same way as they have
+been shuffled.
+
+### Note:
+- The function can also take in an optional `seed` value of type `Option<u64>` for deterministic results.
+
+## Return:
+The return value is a tuple containing two offsprings of type `Vec<bool>`
+
+## Example:
+```rust
+use genx::crossover::shuffle_crossover;
+
+let parent1 = vec![true, false, false, true, true, false, false, true];
+let parent2 = vec![true, true, true, false, true, false, true, true];
+let (child1, child2) = shuffle_crossover(&parent1, &parent2, None);
+```
+ */
 pub fn shuffle_crossover(parent1: &Vec<bool>, parent2: &Vec<bool>, seed: Option<u64>) -> (Vec<bool>, Vec<bool>) {
   check_length(parent1, parent2);
 

--- a/src/crossover/simulated_binary.rs
+++ b/src/crossover/simulated_binary.rs
@@ -1,5 +1,25 @@
 use rand::{Rng, SeedableRng, prelude::StdRng};
 
+/**
+## Description:
+Simulated binary crossover uses probability density function that simulates the single-point
+crossover in binary-coded GAs.
+
+### Note:
+- The function takes a `f32` parameter `operator` denoting SBX crossover distribution factor.
+- The function can also take in an optional `seed` value of type `Option<u64>` for deterministic results.
+
+## Return:
+The return value is a tuple containing two offsprings of type `f32`
+
+## Example:
+```rust
+use genx::crossover::simulated_binary_crossover;
+
+let (parent1, parent2) = (11.19, 20.97);
+let (child1, child2) = simulated_binary_crossover(parent1, parent2, 0.5, None);
+```
+ */
 pub fn simulated_binary_crossover(parent1: f32, parent2: f32, operator: f32, seed: Option<u64>) -> (f32, f32) {
   let mut prng = match seed {
       Some(val) => StdRng::seed_from_u64(val),

--- a/src/crossover/single_point.rs
+++ b/src/crossover/single_point.rs
@@ -2,6 +2,27 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 
 use super::check_length;
 
+/**
+## Description:
+It is one of the simple crossover technique used for random GA applications. This crossover
+uses the single point fragmentation of the parents and then combines the parents at the
+crossover point to create the offspring or child.
+
+### Note:
+- The function can also take in an optional `seed` value of type `Option<u64>` for deterministic results.
+
+## Return:
+The return value is a tuple containing two offsprings of type `Vec<bool>`
+
+## Example:
+```rust
+use genx::crossover::single_point_crossover;
+
+let parent1 = vec![true, false, false, true, true, false, false, true];
+let parent2 = vec![true, true, true, false, true, false, true, true];
+let (child1, child2) = single_point_crossover(&parent1, &parent2, None);
+```
+ */
 pub fn single_point_crossover(
     parent1: &Vec<bool>,
     parent2: &Vec<bool>,

--- a/src/crossover/uniform.rs
+++ b/src/crossover/uniform.rs
@@ -4,6 +4,28 @@ use std::mem::swap;
 
 use super::check_length;
 
+/**
+## Description:
+Uniform crossover selects the two parents for crossover. It creates two child offspring of n genes
+selected from both of the parents uniformly. The random real number decides whether the first child
+select the ith genes from first or second parent.
+
+### Note:
+- The function takes a float value `probability` in the range [0.0 - 1.0] representing the bias.
+- The function can also take in an optional `seed` value of type `Option<u64>` for deterministic results.
+
+## Return:
+The return value is a tuple containing two offsprings of type `Vec<bool>`
+
+## Example:
+```rust
+use genx::crossover::uniform_crossover;
+
+let parent1 = vec![true, false, false, true, true, false, false, true];
+let parent2 = vec![true, true, true, false, true, false, true, true];
+let (child1, child2) = uniform_crossover(&parent1, &parent2, 0.6, None);
+```
+ */
 pub fn uniform_crossover(
     parent1: &Vec<bool>,
     parent2: &Vec<bool>,


### PR DESCRIPTION
Added documentation for the following crossovers:
- [x] blend
- [x] cycle
- [x] linear
- [x] multi_point
- [x] order
- [x] partially_mapped
- [x] shuffle
- [x] simulated_binary
- [x] single_point
- [x] uniform
- [ ] uniform_partially_mapped